### PR TITLE
fix the terminal launch

### DIFF
--- a/main.py
+++ b/main.py
@@ -61,10 +61,10 @@ class SshExtension(Extension):
         shell = os.environ["SHELL"]
         home = expanduser("~")
 
-        cmd = self.terminal_cmd.replace("%SHELL", shell).replace("%CONN", addr)
+        cmd = self.terminal_cmd.replace("%SHELL", shell).replace("%CONN", addr).split()
 
         if self.terminal:
-            subprocess.Popen([self.terminal, self.terminal_arg, cmd], cwd=home)
+            subprocess.Popen([self.terminal, self.terminal_arg] + cmd, cwd=home)
 
 class ItemEnterEventListener(EventListener):
 

--- a/main.py
+++ b/main.py
@@ -61,10 +61,10 @@ class SshExtension(Extension):
         shell = os.environ["SHELL"]
         home = expanduser("~")
 
-        cmd = self.terminal_cmd.replace("%SHELL", shell).replace("%CONN", addr).split()
+        cmd = self.terminal_cmd.replace("%SHELL", shell).replace("%CONN", addr)
 
         if self.terminal:
-            subprocess.Popen([self.terminal, self.terminal_arg] + cmd, cwd=home)
+            subprocess.Popen(self.terminal + " " + self.terminal_arg + " " + cmd, cwd=home, shell=True)
 
 class ItemEnterEventListener(EventListener):
 


### PR DESCRIPTION
Hey,
some terminals will try to utilize the arguments they are given by `Popen` as whole strings.
This fails since `cmd` contains the whole line like ` ssh root@<host>`, which obviously is not a valid binary.
I encountered this behavior with kitty, but maybe this also concerns #4 

To fix this I simply split the `cmd` into a list and concatenate this when launching the terminal.