### PR TITLE
add option to ignore known_hosts

### DIFF
--- a/main.py
+++ b/main.py
@@ -82,6 +82,8 @@ class PreferencesUpdateEventListener(EventListener):
             extension.terminal_arg = event.new_value
         elif event.id == "ssh_launcher_terminal_cmd":
             extension.terminal_cmd = event.new_value
+        elif event.id == "ssh_launcher_use_known_hosts":
+            extension.use_known_hosts = event.new_value
 
 class PreferencesEventListener(EventListener):
 
@@ -89,6 +91,7 @@ class PreferencesEventListener(EventListener):
         extension.terminal = event.preferences["ssh_launcher_terminal"]
         extension.terminal_arg = event.preferences["ssh_launcher_terminal_arg"]
         extension.terminal_cmd = event.preferences["ssh_launcher_terminal_cmd"]
+        extension.use_known_hosts = event.preferences["ssh_launcher_use_known_hosts"]
 
 class KeywordQueryEventListener(EventListener):
 
@@ -97,7 +100,8 @@ class KeywordQueryEventListener(EventListener):
         items = []
         arg = event.get_argument()
         hosts = extension.parse_ssh_config()
-        hosts += extension.parse_known_hosts()
+        if extension.use_known_hosts == "True":
+            hosts += extension.parse_known_hosts()
 
         hosts.sort()
 

--- a/manifest.json
+++ b/manifest.json
@@ -5,16 +5,16 @@
   "developer_name": "Jonas Bendlin",
   "icon": "images/icon.png",
   "options": {
-    "query_debounce": 0.1
+	"query_debounce": 0.1
   },
   "preferences": [
-    {
-      "id": "ssh_launcher_kw",
-      "type": "keyword",
-      "name": "SSH Launcher",
-      "description": "",
-      "default_value": "ssh"
-    },
+	{
+	  "id": "ssh_launcher_kw",
+	  "type": "keyword",
+	  "name": "SSH Launcher",
+	  "description": "",
+	  "default_value": "ssh"
+	},
 	{
 		"id": "ssh_launcher_terminal",
 		"type": "input",
@@ -35,6 +35,23 @@
 		"name": "Terminal cmd",
 		"description": "The command to start the terminal with. %SHELL equals the env var $SHELL and %CONN the selected connection.",
 		"default_value": "%SHELL -c 'ssh \"%CONN\"';%SHELL"
+	},
+	{
+		"id": "ssh_launcher_use_known_hosts",
+		"type": "select",
+		"name": "Use known_hosts",
+		"description": "Parse the ~/.ssh/known_hosts file for more suggestions.",
+		"options": [
+			{
+				"value": "True",
+				"text": "Yes"
+			},
+			{
+				"value": "False",
+				"text": "No"
+			}
+		],
+		"default_value": "True"
 	}
   ]
 }


### PR DESCRIPTION
Hey,
I added an option to ignore the `known_hosts` file as I personally don't like having tons of IPs among the suggestions.
It should default to including the file to not change the default behavior from before.